### PR TITLE
fix(helm): use valid GHCR image path format in defaults

### DIFF
--- a/helm/local-pulse/values.schema.json
+++ b/helm/local-pulse/values.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "go": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Image registry and org (e.g. ghcr.io/YOUR_ORG). Must include org for GHCR.",
+              "pattern": ".*/.*",
+              "minLength": 3
+            }
+          }
+        },
+        "python": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Image registry and org (e.g. ghcr.io/YOUR_ORG). Must include org for GHCR.",
+              "pattern": ".*/.*",
+              "minLength": 3
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helm/local-pulse/values.yaml
+++ b/helm/local-pulse/values.yaml
@@ -1,15 +1,16 @@
 # Default values for local-pulse
 
-# Image settings - set repository to ghcr.io/YOUR_GITHUB_ORG for GHCR
-# e.g. repository: ghcr.io/myorg -> ghcr.io/myorg/local-pulse-go
+# Image settings - REQUIRED: set repository to ghcr.io/YOUR_GITHUB_ORG for GHCR
+# GHCR requires images as ghcr.io/owner/repo (e.g. ghcr.io/resnostyle/local-pulse-go)
+# Override: --set image.go.repository=ghcr.io/YOUR_ORG --set image.python.repository=ghcr.io/YOUR_ORG
 image:
   go:
-    repository: ghcr.io
+    repository: ghcr.io/YOUR_GITHUB_ORG
     name: local-pulse-go
     tag: latest
     pullPolicy: IfNotPresent
   python:
-    repository: ghcr.io
+    repository: ghcr.io/YOUR_GITHUB_ORG
     name: local-pulse-python
     tag: latest
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
Resolves #19

Changes the Helm chart default image values so the resulting image path follows GHCR's required `ghcr.io/owner/repo` format.

## Changes
- **values.yaml**: Change `image.go.repository` and `image.python.repository` default from `ghcr.io` to `ghcr.io/YOUR_GITHUB_ORG`
- **values.schema.json**: Add schema validation requiring repository to include org segment (pattern `.*/.*`)

## Before
```
image: ghcr.io/local-pulse-go:latest  # Invalid - missing owner
```

## After
```
image: ghcr.io/YOUR_GITHUB_ORG/local-pulse-go:latest  # Valid format - user replaces placeholder
```

Users must override with `--set image.go.repository=ghcr.io/their-org` or set in values.

Made with [Cursor](https://cursor.com)