### PR TITLE
fix(mise): add required 'run' argument to python task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -36,8 +36,8 @@ echo "Database ready."
 """
 
 [tasks.python]
-description = "Run Python ingestion service"
-run = "cd python && python main.py"
+description = "Run Python ingestion service (one-shot)"
+run = "cd python && python main.py run"
 
 [tasks.python-install]
 description = "Install Python dependencies"


### PR DESCRIPTION
## Summary
Resolves #18

The `mise run python` task was failing because it ran `python main.py` without arguments. main.py requires `run` or `schedule` and exits with code 1.

## Changes
- Add `run` argument for one-shot ingestion: `python main.py run`
- Update task description to clarify one-shot behavior

Made with [Cursor](https://cursor.com)