### PR TITLE
feat: add GET /health endpoint for probes and monitoring

### DIFF
--- a/go/handlers/handlers.go
+++ b/go/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"database/sql"
+	"encoding/json"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -16,6 +17,18 @@ import (
 type APIHandler struct {
 	DB   *sql.DB
 	Tmpl *template.Template
+}
+
+// Health handles GET /health. Returns 200 if DB is reachable, 503 otherwise.
+func (h *APIHandler) Health(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := h.DB.Ping(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"status": "unhealthy"})
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // eventsPageData holds data for the events page.

--- a/go/handlers/handlers_test.go
+++ b/go/handlers/handlers_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"encoding/json"
+	"errors"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,70 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestHealth_Returns200WhenDBHealthy(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing()
+
+	tmpl := template.Must(template.New("").Parse(""))
+	h := &APIHandler{DB: db, Tmpl: tmpl}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	h.Health(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Health: status = %d, want 200", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Health: invalid JSON: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("Health: status = %q, want ok", body["status"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestHealth_Returns503WhenDBUnhealthy(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(errors.New("connection refused"))
+
+	tmpl := template.Must(template.New("").Parse(""))
+	h := &APIHandler{DB: db, Tmpl: tmpl}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	h.Health(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("Health: status = %d, want 503", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Health: invalid JSON: %v", err)
+	}
+	if body["status"] != "unhealthy" {
+		t.Errorf("Health: status = %q, want unhealthy", body["status"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
 
 func TestParsePage(t *testing.T) {
 	tests := []struct {

--- a/go/main.go
+++ b/go/main.go
@@ -55,6 +55,7 @@ func main() {
 	h := &handlers.APIHandler{DB: conn, Tmpl: tmpl}
 	mux := http.NewServeMux()
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+	mux.HandleFunc("/health", h.Health)
 	mux.HandleFunc("/", h.Index)
 	mux.HandleFunc("/events", h.EventsHTML)
 	mux.HandleFunc("/events/today", h.EventsTodayHTML)

--- a/helm/local-pulse/templates/deployment-go.yaml
+++ b/helm/local-pulse/templates/deployment-go.yaml
@@ -48,14 +48,14 @@ spec:
                   key: MYSQL_PASSWORD
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
## Summary
Resolves #12

Add `GET /health` endpoint for Kubernetes liveness/readiness probes, load balancers, and monitoring.

## Changes
- **handlers.go**: Add `Health` handler that pings MySQL and returns:
  - `200` with `{"status":"ok"}` when DB is reachable
  - `503` with `{"status":"unhealthy"}` when DB ping fails
- **main.go**: Register `/health` route
- **deployment-go.yaml**: Update liveness and readiness probes to use `/health` instead of `/` (lighter weight, DB-aware)
- **handlers_test.go**: Add `TestHealth_Returns200WhenDBHealthy` and `TestHealth_Returns503WhenDBUnhealthy`

Made with [Cursor](https://cursor.com)