### PR TITLE
Harden GitLab CI pipelines for production deployment.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,23 +5,32 @@
 # Events:   R2 custom domain — proxied via Cloudflare CDN (see docs/DEPLOY.md)
 #
 # Required GitLab CI/CD variables (non-secret):
-#   VAULT_ADDR                          e.g. https://vault.example.com
-#   VAULT_TERRAFORM_CLOUDFLARE_TOKEN_PATH  e.g. localpulse/terraform/cloudflare_api_token@secret
-#   VAULT_OPENAI_API_KEY_PATH           e.g. localpulse/openai/api_key@secret
-#   VAULT_R2_ACCESS_KEY_ID_PATH         e.g. localpulse/r2/access_key_id@secret
-#   VAULT_R2_SECRET_ACCESS_KEY_PATH     e.g. localpulse/r2/secret_access_key@secret
+#   VAULT_ADDR
 #   TF_VAR_cloudflare_account_id
 #   TF_VAR_events_custom_domain         e.g. events.example.com
 #   TF_VAR_cloudflare_zone_id           required when events_custom_domain is set
-#   VITE_EVENTS_BASE                    e.g. https://events.example.com/events
 #
-# R2_BUCKET / R2_ENDPOINT: set after first terraform apply (terraform output or terraform.env)
+# Optional overrides (otherwise from terraform:dotenv on main, or set manually):
+#   R2_BUCKET, R2_ENDPOINT, VITE_EVENTS_BASE
+#
+# Vault paths (defaults below): Cloudflare token, R2 keys, OpenAI key — see docs/VAULT.md
+#
 # Schedule ingest: CI/CD → Schedules → 0 */3 * * *
-# Manual force ingest: run pipeline with RUN_INGEST=true and RUN_INGEST_FORCE=true
+# Manual ingest:   run pipeline with RUN_INGEST=true
+# Force all sources: add RUN_INGEST_FORCE=true
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web"
 
 include:
   - local: .gitlab/ci/terraform.yml
   - local: .gitlab/ci/vault-secrets.yml
+  - local: .gitlab/ci/ingest.yml
+  - local: .gitlab/ci/pages.yml
 
 stages:
   - test
@@ -34,7 +43,6 @@ stages:
 variables:
   LOCALPULSE_DATA_ROOT: "$CI_PROJECT_DIR/data"
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
-  # Vault secret path defaults (override in GitLab CI/CD settings)
   VAULT_TERRAFORM_CLOUDFLARE_TOKEN_PATH: "localpulse/terraform/cloudflare_api_token@secret"
   VAULT_OPENAI_API_KEY_PATH: "localpulse/openai/api_key@secret"
   VAULT_R2_ACCESS_KEY_ID_PATH: "localpulse/r2/access_key_id@secret"
@@ -47,6 +55,10 @@ variables:
     paths:
       - .cache/pip
   before_script:
+    - |
+      if [ ! -f python/config/calendars.yaml ]; then
+        cp python/config/calendars.yaml.example python/config/calendars.yaml
+      fi
     - cd python && pip install -q -r requirements.txt
 
 test:python:
@@ -56,66 +68,4 @@ test:python:
     - cd python && python -m pytest tests/ -q
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
-ingest:pipeline:
-  extends:
-    - .python_job
-    - .ingest_vault
-  stage: ingest
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_PIPELINE_SOURCE == "web" && $RUN_INGEST == "true"
-  before_script:
-    - apt-get update -qq && apt-get install -y -qq awscli
-    - |
-      if [ ! -f python/config/calendars.yaml ]; then
-        cp python/config/calendars.yaml.example python/config/calendars.yaml
-      fi
-    - cd python && pip install -q -r requirements.txt
-    - mkdir -p "$LOCALPULSE_DATA_ROOT/meta" "$LOCALPULSE_DATA_ROOT/raw" "$LOCALPULSE_DATA_ROOT/events"
-    - |
-      if [ -n "$R2_BUCKET" ] && [ -n "$R2_ENDPOINT" ]; then
-        export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-        export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-        aws s3 sync "s3://${R2_BUCKET}/meta/" "$LOCALPULSE_DATA_ROOT/meta/" \
-          --endpoint-url "$R2_ENDPOINT" || true
-        aws s3 sync "s3://${R2_BUCKET}/raw/" "$LOCALPULSE_DATA_ROOT/raw/" \
-          --endpoint-url "$R2_ENDPOINT" || true
-      fi
-  script:
-    - |
-      cd python
-      if [ "$RUN_INGEST_FORCE" = "true" ]; then
-        python main.py run --force
-      else
-        python main.py run
-      fi
-    - |
-      if [ -n "$R2_BUCKET" ] && [ -n "$R2_ENDPOINT" ]; then
-        export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-        export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-        aws s3 sync "$LOCALPULSE_DATA_ROOT/meta/" "s3://${R2_BUCKET}/meta/" --endpoint-url "$R2_ENDPOINT"
-        aws s3 sync "$LOCALPULSE_DATA_ROOT/raw/" "s3://${R2_BUCKET}/raw/" --endpoint-url "$R2_ENDPOINT"
-        aws s3 sync "$LOCALPULSE_DATA_ROOT/events/" "s3://${R2_BUCKET}/events/" --endpoint-url "$R2_ENDPOINT"
-      fi
-  artifacts:
-    when: on_success
-    paths:
-      - data/events/
-    expire_in: 7 days
-
-pages:
-  stage: pages
-  image: node:20-alpine
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-  variables:
-    # Set in GitLab CI/CD after terraform apply — e.g. https://events.example.com/events
-    VITE_EVENTS_BASE: "${VITE_EVENTS_BASE:-/events}"
-  script:
-    - cd frontend && npm ci && npm run build
-    - mv frontend/dist public
-  artifacts:
-    paths:
-      - public
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"

--- a/.gitlab/ci/ingest.yml
+++ b/.gitlab/ci/ingest.yml
@@ -1,0 +1,83 @@
+# Scheduled / manual scrape → reduce → R2 sync.
+
+.ingest_setup:
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq awscli
+    - |
+      if [ ! -f python/config/calendars.yaml ]; then
+        cp python/config/calendars.yaml.example python/config/calendars.yaml
+      fi
+    - cd python && pip install -q -r requirements.txt
+    - mkdir -p "$LOCALPULSE_DATA_ROOT/meta" "$LOCALPULSE_DATA_ROOT/raw" "$LOCALPULSE_DATA_ROOT/events"
+    - |
+      if [ "$CI_PIPELINE_SOURCE" = "schedule" ] || [ "$RUN_INGEST" = "true" ]; then
+        missing=""
+        [ -z "$R2_BUCKET" ] && missing="${missing} R2_BUCKET"
+        [ -z "$R2_ENDPOINT" ] && missing="${missing} R2_ENDPOINT"
+        [ -z "$R2_ACCESS_KEY_ID" ] && missing="${missing} R2_ACCESS_KEY_ID"
+        [ -z "$R2_SECRET_ACCESS_KEY" ] && missing="${missing} R2_SECRET_ACCESS_KEY"
+        if [ -n "$missing" ]; then
+          echo "ERROR: Missing required variables:${missing}"
+          echo "Set R2_BUCKET and R2_ENDPOINT in CI/CD variables (terraform output)."
+          echo "Store R2 credentials in Vault — see docs/VAULT.md."
+          exit 1
+        fi
+      fi
+    - |
+      if [ -n "$R2_BUCKET" ] && [ -n "$R2_ENDPOINT" ]; then
+        export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+        echo "Pulling meta/ and raw/ from s3://${R2_BUCKET}..."
+        aws s3 sync "s3://${R2_BUCKET}/meta/" "$LOCALPULSE_DATA_ROOT/meta/" \
+          --endpoint-url "$R2_ENDPOINT" || true
+        aws s3 sync "s3://${R2_BUCKET}/raw/" "$LOCALPULSE_DATA_ROOT/raw/" \
+          --endpoint-url "$R2_ENDPOINT" || true
+      else
+        echo "R2_BUCKET/R2_ENDPOINT not set — running without remote state (local meta/raw only)."
+      fi
+
+ingest:pipeline:
+  extends:
+    - .python_job
+    - .ingest_vault
+    - .ingest_setup
+  stage: ingest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web" && $RUN_INGEST == "true"
+  script:
+    - |
+      cd python
+      if [ "$RUN_INGEST_FORCE" = "true" ]; then
+        echo "Running full scrape (--force)..."
+        python main.py run --force
+      else
+        echo "Running scrape for due sources..."
+        python main.py run
+      fi
+    - |
+      if [ -n "$R2_BUCKET" ] && [ -n "$R2_ENDPOINT" ]; then
+        export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+        echo "Pushing meta/ and raw/ to s3://${R2_BUCKET}..."
+        aws s3 sync "$LOCALPULSE_DATA_ROOT/meta/" "s3://${R2_BUCKET}/meta/" \
+          --endpoint-url "$R2_ENDPOINT"
+        aws s3 sync "$LOCALPULSE_DATA_ROOT/raw/" "s3://${R2_BUCKET}/raw/" \
+          --endpoint-url "$R2_ENDPOINT"
+        echo "Pushing events/ to s3://${R2_BUCKET} (removing stale objects)..."
+        aws s3 sync "$LOCALPULSE_DATA_ROOT/events/" "s3://${R2_BUCKET}/events/" \
+          --endpoint-url "$R2_ENDPOINT" \
+          --delete
+        echo "R2 sync complete."
+      fi
+    - |
+      if [ ! -f "$LOCALPULSE_DATA_ROOT/events/index.json" ]; then
+        echo "WARNING: events/index.json was not produced — check calendars.yaml sources."
+        exit 1
+      fi
+      echo "Compiled $(find "$LOCALPULSE_DATA_ROOT/events" -name '*.json' | wc -l) event JSON file(s)."
+  artifacts:
+    when: on_success
+    paths:
+      - data/events/
+    expire_in: 7 days

--- a/.gitlab/ci/pages.yml
+++ b/.gitlab/ci/pages.yml
@@ -1,0 +1,48 @@
+# GitLab Pages — React SPA built with VITE_EVENTS_BASE from CI or terraform dotenv.
+
+.node_cache:
+  cache:
+    key: npm-$CI_COMMIT_REF_SLUG
+    paths:
+      - frontend/node_modules/
+
+test:frontend:
+  extends: .node_cache
+  stage: test
+  image: node:20-alpine
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      changes:
+        - frontend/**/*
+        - .gitlab-ci.yml
+        - .gitlab/ci/**/*
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      changes:
+        - frontend/**/*
+        - .gitlab-ci.yml
+        - .gitlab/ci/**/*
+  script:
+    - cd frontend && npm ci
+    - npm run build
+  variables:
+    VITE_EVENTS_BASE: "${VITE_EVENTS_BASE:-/events}"
+
+pages:
+  extends: .node_cache
+  stage: pages
+  image: node:20-alpine
+  needs:
+    - job: terraform:dotenv
+      optional: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "web"
+  variables:
+    VITE_EVENTS_BASE: "${VITE_EVENTS_BASE:-/events}"
+  script:
+    - echo "Building with VITE_EVENTS_BASE=${VITE_EVENTS_BASE}"
+    - cd frontend && npm ci && npm run build
+    - mv frontend/dist public
+  artifacts:
+    paths:
+      - public

--- a/.gitlab/ci/terraform.yml
+++ b/.gitlab/ci/terraform.yml
@@ -99,15 +99,36 @@ terraform:apply:
         - .gitlab-ci.yml
   script:
     - terraform apply -input=false -auto-approve plan.cache
+
+# Export R2 bucket / events URL for pages on main pushes (reads remote state, no apply).
+.terraform_dotenv_script:
+  script:
     - |
       cd "${TF_ROOT}"
-      echo "R2_BUCKET=$(terraform output -raw bucket_name)" >> "${CI_PROJECT_DIR}/terraform.env"
-      echo "R2_ENDPOINT=$(terraform output -raw r2_endpoint)" >> "${CI_PROJECT_DIR}/terraform.env"
-      EVENTS_BASE=$(terraform output -raw events_base_url 2>/dev/null || true)
-      if [ -n "$EVENTS_BASE" ] && [ "$EVENTS_BASE" != "null" ]; then
-        echo "VITE_EVENTS_BASE=${EVENTS_BASE}" >> "${CI_PROJECT_DIR}/terraform.env"
-      fi
+      {
+        echo "R2_BUCKET=$(terraform output -raw bucket_name)"
+        echo "R2_ENDPOINT=$(terraform output -raw r2_endpoint)"
+        EVENTS_BASE=$(terraform output -raw events_base_url 2>/dev/null || true)
+        if [ -n "$EVENTS_BASE" ] && [ "$EVENTS_BASE" != "null" ]; then
+          echo "VITE_EVENTS_BASE=${EVENTS_BASE}"
+        fi
+      } > "${CI_PROJECT_DIR}/terraform.env"
+      cat "${CI_PROJECT_DIR}/terraform.env"
+
+terraform:dotenv:
+  extends:
+    - .terraform_image
+    - .terraform_vars
+    - .terraform_vault
+    - .terraform_init
+  stage: apply
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "web"
+  script:
+    - !reference [.terraform_dotenv_script, script]
   artifacts:
     reports:
       dotenv: terraform.env
     expire_in: 30 days
+  allow_failure: true

--- a/docs/VAULT.md
+++ b/docs/VAULT.md
@@ -97,14 +97,18 @@ Scope policies per environment (`localpulse/staging/*` vs `localpulse/production
 ## 5. Pipeline behaviour
 
 ```
-MR / main (terraform/** changed)
-  validate → plan (artifact: plan.cache)
+push / MR
+  test:python (+ test:frontend when frontend/ changes)
+  terraform validate/plan/apply (when terraform/ changes)
+  terraform:dotenv (main push only → R2_BUCKET, R2_ENDPOINT, VITE_EVENTS_BASE)
+  pages (main push only → GitLab Pages build)
 
-main only
-  apply (auto-approve plan.cache) → writes terraform.env dotenv (R2_BUCKET, R2_ENDPOINT, VITE_EVENTS_BASE)
+schedule (0 */3 * * *)
+  ingest:pipeline only (Vault R2 + OpenAI secrets)
 
-schedule
-  ingest:pipeline (Vault R2 + OpenAI secrets)
+web (manual)
+  RUN_INGEST=true  → ingest:pipeline
+  RUN_INGEST_FORCE=true → scrape all sources, ignore intervals
 ```
 
 **Apply is automatic on the default branch** when Terraform files change. There is no manual approval gate.


### PR DESCRIPTION
Split ingest and pages into dedicated CI includes, add terraform dotenv export for Pages builds, validate R2 config on scheduled ingest, delete stale events on R2 sync, and skip Pages/terraform on schedule-only pipelines.
